### PR TITLE
Update draw results filter

### DIFF
--- a/src/helpers/filterResultsByValue.ts
+++ b/src/helpers/filterResultsByValue.ts
@@ -1,32 +1,50 @@
-import { BigNumber } from "ethers";
-import { DrawResults, PrizeAwardable } from "types";
+import { BigNumber } from 'ethers';
+import { DrawResults, PrizeAwardable } from 'types';
 
-const debug = require('debug')('pt:tsunami-sdk-drawCalculator')
+const debug = require('debug')('pt:tsunami-sdk-drawCalculator');
 
-export function filterResultsByValue(drawResults: DrawResults, maxPicksPerUser: number) : DrawResults{
-    // if the user has more winning picks than max pick per user for the draw, we sort by value and remove the lowest value picks
-    if(drawResults.prizes.length > maxPicksPerUser){
-        
-        debug(`user has more claims (${drawResults.prizes.length}) than the max picks per user (${maxPicksPerUser}). Sorting..`)
-        // sort by value
-        const descendingSortedPrizes : PrizeAwardable[]= drawResults.prizes.sort(
-            function(a : PrizeAwardable, b: PrizeAwardable) : number {
-                const subbedValue = a.amount.sub(b.amount)
-                if (subbedValue.isZero()) return 0
-                if (subbedValue.isNegative()) return -1
-                return 1
-            })
-        // remove the lowest value picks up to the max picks per user
-        const sortedDescendingSortedPrizes = descendingSortedPrizes.slice(0, maxPicksPerUser).filter(prizeAwardable => !prizeAwardable.amount.isZero())
-        // sum the sorted values
-        const newTotalValue : BigNumber = descendingSortedPrizes.reduce((accumulator, currentValue) => accumulator.add(currentValue.amount), BigNumber.from(0))
-        return {
-            ...drawResults,
-            totalValue: newTotalValue,
-            prizes: sortedDescendingSortedPrizes
-        } 
+/**
+ * Filters out prizes if:
+ * - there's more prizes than the max picks per user
+ * - the prize won is 0 tokens
+ *
+ * Sorts prizes by descending value too.
+ * @param drawResults
+ * @param maxPicksPerUser
+ * @returns
+ */
+export function filterResultsByValue(
+    drawResults: DrawResults,
+    maxPicksPerUser: number,
+): DrawResults {
+    // sort by value
+    let newPrizes = drawResults.prizes.filter(filterZeroPrizeAmount).sort(sortByPrizeAmount);
+    let newTotalValue = drawResults.totalValue;
+
+    // If there's too many prizes to claim, slice & sum total value
+    if (drawResults.prizes.length > maxPicksPerUser) {
+        debug(
+            `user has more claims (${drawResults.prizes.length}) than the max picks per user (${maxPicksPerUser}). Sorting..`,
+        );
+        newPrizes = newPrizes.slice(0, maxPicksPerUser);
+        newTotalValue = newPrizes.reduce(
+            (accumulator, currentValue) => accumulator.add(currentValue.amount),
+            BigNumber.from(0),
+        );
     }
 
-    // if not greater than max picks per user, return the whole array
-    return drawResults
+    return {
+        ...drawResults,
+        totalValue: newTotalValue,
+        prizes: newPrizes,
+    };
 }
+
+const sortByPrizeAmount = (a: PrizeAwardable, b: PrizeAwardable) => {
+    const subbedValue = a.amount.sub(b.amount);
+    if (subbedValue.isZero()) return 0;
+    if (subbedValue.isNegative()) return -1;
+    return 1;
+};
+
+const filterZeroPrizeAmount = (prizeAwardable: PrizeAwardable) => !prizeAwardable.amount.isZero();

--- a/test/batchCalculateDrawResults.test.ts
+++ b/test/batchCalculateDrawResults.test.ts
@@ -13,7 +13,7 @@ import { calculatePrizeForDistributionIndex } from '../src/helpers/calculatePriz
 const formatDistributionNumber = (distribution: string) =>
     utils.parseUnits(distribution, 9).toNumber();
 
-describe.only('batchCalculateDrawResults()', () => {
+describe('batchCalculateDrawResults()', () => {
     it('Single DrawCalculator run 1 matches', async () => {
         // distributionIndex = matchCardinality - numberOfMatches = 3 - 1 = 2
         // distributions[2] = 0.1e18 = prizeAtIndex
@@ -47,7 +47,11 @@ describe.only('batchCalculateDrawResults()', () => {
             normalizedBalances: [ethers.utils.parseEther('0.2')],
         };
 
-        const results = batchCalculateDrawResults([exampleDrawSettings], [exampleDraw], exampleUser);
+        const results = batchCalculateDrawResults(
+            [exampleDrawSettings],
+            [exampleDraw],
+            exampleUser,
+        );
         const expectedPrize = BigNumber.from('0x94a62bef705e30'); // const prizeReceived = utils.parseEther("0.041666666666666667")
         expect(results[0].totalValue).to.deep.equal(expectedPrize);
     });
@@ -84,7 +88,11 @@ describe.only('batchCalculateDrawResults()', () => {
             winningRandomNumber: BigNumber.from(winningRandomNumber),
         };
 
-        const results = batchCalculateDrawResults([exampleDrawSettings], [exampleDraw], exampleUser);
+        const results = batchCalculateDrawResults(
+            [exampleDrawSettings],
+            [exampleDraw],
+            exampleUser,
+        );
         const prizeReceived = utils.parseEther('40');
         expect(results[0].totalValue).to.deep.equal(prizeReceived);
     });
@@ -308,7 +316,11 @@ describe('prepareClaimForUserFromDrawResult()', () => {
             normalizedBalances: [ethers.utils.parseEther('10')],
         };
 
-        const drawResult = batchCalculateDrawResults([exampleDrawSettings], [exampleDraw], exampleUser);
+        const drawResult = batchCalculateDrawResults(
+            [exampleDrawSettings],
+            [exampleDraw],
+            exampleUser,
+        );
 
         const claimResult: Claim = prepareClaims(exampleUser, drawResult);
         expect(claimResult.drawIds).to.deep.equal([drawId]);


### PR DESCRIPTION
- Makes sorting consistent
- Remove $0 prizes all of the time. Previously it only happened if `prizes.length` > `maxPicksPerUser`